### PR TITLE
Set box-sizing to border-box

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,9 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
Setting `box-sizing` to `border-box` feels more intuitive and should be set globally throughout our app.

> `border-box` tells the browser to account for any border and padding in the values you specify for an element's `width` and `height`. If you set an element's width to 100 pixels, that 100 pixels will include any border or padding you added, and the content box will shrink to absorb that extra width. This typically makes it much easier to size elements.
- [More info](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing)